### PR TITLE
Remove passing frameworkcode to C4::Biblio->GetMarcFromKohaField()

### DIFF
--- a/lib/NCIP/ILS/Koha.pm
+++ b/lib/NCIP/ILS/Koha.pm
@@ -834,7 +834,7 @@ sub acceptitem {
     my $item_callnumber = $iteminfo->{itemcallnumber} || $config->{item_callnumber} || q{};
 
     my ( $field, $subfield ) =
-      GetMarcFromKohaField( 'biblioitems.itemtype', $frameworkcode );
+      GetMarcFromKohaField( 'biblioitems.itemtype' );
     ( $field, $subfield ) =
       GetMarcFromKohaField( 'biblioitems.itemtype' ) unless $field && $subfield;
 


### PR DESCRIPTION
Since bugs
https://bugs.koha-community.org/bugzilla3/show_bug.cgi?id=19096 and https://bugs.koha-community.org/bugzilla3/show_bug.cgi?id=19097 were pushed to Koha the GetMarcFromKohaField() no longer accepts a frameworkcode parameter.